### PR TITLE
Chore: Default path_prefix to the repository root

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ to prevent injection attacks.
 | ------------- | -------- | ------- | ---------------------------------------------- |
 | node_version  | False    | 22      | Node.js version for build/install              |
 | build_tool    | False    | npm     | Build tool [npm/yarn]                          |
-| path_prefix   | False    |         | Path to Node.js project code                   |
+| path_prefix   | False    | .       | Path to Node.js project code                   |
 | npm_flags     | False    |         | Flags for npm (allowlist enforced)             |
 | yarn_flags    | False    |         | Flags for yarn (allowlist enforced)            |
 | scripts       | False    | build   | Scripts to run (comma/space/newline-separated) |

--- a/action.yaml
+++ b/action.yaml
@@ -18,6 +18,7 @@ inputs:
   path_prefix:
     description: 'Path/directory to Node.js project code'
     required: false
+    default: '.'
   npm_flags:
     description: 'Flags to pass to npm'
     required: false


### PR DESCRIPTION
## Chore: Default `path_prefix` to the repository root

Every sibling action in this organisation declares `path_prefix` with a `.` default — 28 of them. This one omitted it, so the declared interface didn't state where the action looks by default, and callers had to infer it or read the implementation.

## Behaviour is unchanged

The action **already normalises an empty value to `.`** internally:

```bash
path_prefix="${{ inputs.path_prefix }}"
if [ -z "$path_prefix" ]; then
  path_prefix="."
fi
```

So this makes the declared interface match what the implementation always did. The practical gain is that GitHub surfaces the default in the Actions UI and in generated documentation, rather than leaving it blank.

## Context

Part of a small consistency sweep across the estate, alongside [`gradle-build-action#103`](https://github.com/lfreleng-actions/gradle-build-action/pull/103), which aligns that action's outlier `path` input onto `path_prefix`.

Deliberately **not** included in the sweep: `python-audit-action`, which defaults `path_prefix` to `''`. That empty default is load-bearing — it is passed to `pypa/gh-action-pip-audit` as `inputs:`, where empty means *"audit the installed environment"* (which the action has just populated with the built wheel) while `'.'` would mean *"scan this directory"*. Changing it there would alter what gets audited.

## Validation

`pre-commit run --all-files` — all hooks pass.